### PR TITLE
Fix wrong variable in _get_rocm_version()

### DIFF
--- a/triton_dejavu/__init__.py
+++ b/triton_dejavu/__init__.py
@@ -15,7 +15,7 @@
 #  *******************************************************************************/
 #
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 from .dejavu_storage import global_dejavu_storage

--- a/triton_dejavu/dejavu_utilities.py
+++ b/triton_dejavu/dejavu_utilities.py
@@ -116,10 +116,10 @@ def _get_rocm_version():
     except Exception as e:
         if flag_print_debug:
             print(f"[triton-dejavu] determining rocm version failed with: {e}")
-        cuda_version = os.environ.get("CONTAINER_ROCM_VERSION", "unknown")
-        if cuda_version == "unknown":
+        rocm_version = os.environ.get("CONTAINER_ROCM_VERSION", "unknown")
+        if rocm_version == "unknown":
             raise Exception(
-                "Can't determine cuda version and also CONTAINER_ROCM_VERSION is not set"
+                "Can't determine rocm version and also CONTAINER_ROCM_VERSION is not set"
             )
     os.environ["_TRITON_DEJAVU_DETERMINED_ROCM_VERSION"] = rocm_version
     return rocm_version


### PR DESCRIPTION
G'day,

I've finally gotten around to testing the rocm version properly, and I think there's a possible copy paste error in the code branch that checks `CONTAINER_ROCM_VERSION`? (The normal code branch doesn't work for me because `amdgpu_arch_path` is missing, but I think this is just an idiosyncrasy of the way my computing cluster has set everything up...)

Thanks!