### PR TITLE
Remove fast_flush parameter from do_bench

### DIFF
--- a/triton_dejavu/autotuner.py
+++ b/triton_dejavu/autotuner.py
@@ -263,7 +263,6 @@ class Autotuner(KernelInterface):
                 warmup=self.warmup_t,
                 rep=self.rep_t,
                 quantiles=(0.5, 0.2, 0.8),
-                fast_flush=False,
             )
         except (
             OutOfResources,


### PR DESCRIPTION
The fast_flush parameter was removed in Triton (see https://github.com/triton-lang/triton/pull/4485). Its presence in this code now raises an error, as the parameter is no longer supported.

This change ensures compatibility with the updated Triton code.

Signed-off-by: Alessandro Sangiorgi <asangior@redhat.com>