### PR TITLE
Adding JIT cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Triton Deja-vu
 Framework to reduce autotune overhead of [triton-lang](https://github.com/triton-lang/triton) to zero for well known deployments.
 
 This small framework is based on the [Triton autotuner](https://github.com/triton-lang/triton/blob/main/python/triton/runtime/autotuner.py) and contributes three features to the Triton community:
-1. Store and safely restore autotuner states using JSON files. 
+1. Store and safely restore autotuner states using JSON files.
 2. `ConfigSpaces` to explore a defined space exhaustively.
 3. Bayesian Optimization to speed up the autotuning process.
 
-Additionally, it allows to use heuristics in combination with the autotuner. Please find more details in the [feature section below](#features). 
+Additionally, it allows to use heuristics in combination with the autotuner. Please find more details in the [feature section below](#features).
 
 Besides improvements for autotuning, it also contains useful tools in working with triton, specifically a [cache for JIT-artifacts](#jitcache).
 
@@ -33,7 +33,7 @@ import triton_dejavu
 @triton_dejavu.autotune(
     ...
 ```
-Second, the environment variable `TRITON_DEJAVU_STORAGE` needs to be set and point to a read and writable directory. 
+Second, the environment variable `TRITON_DEJAVU_STORAGE` needs to be set and point to a read and writable directory.
 
 
 To use the `ConfigSpaces` feature, replace the `config` parameter for the triton_dejavu autotuner with  `config_space` definition:
@@ -92,7 +92,7 @@ So far, we think that the above listed combination determines the applicability 
 
 In addition, users can define a tag to be used by the dejavu storage to be able to differentiate different deployment scenarios (for otherwise identical value combinations).
 
-Please note, the above list does not include features that do not influence the decision of the autotuner, but influence the behaviour of the kernel or the JIT. For example, the precense or details of `pre_hook` or `post_hook` and also other [`specialization_data`](https://github.com/triton-lang/triton/blob/e87f877eb94efeaeb4ad8697f315932121dec5e0/python/triton/runtime/jit.py#L514) used by the JIT cache are not used by triton-dejavu. 
+Please note, the above list does not include features that do not influence the decision of the autotuner, but influence the behaviour of the kernel or the JIT. For example, the presence or details of `pre_hook` or `post_hook` and also other [`specialization_data`](https://github.com/triton-lang/triton/blob/e87f877eb94efeaeb4ad8697f315932121dec5e0/python/triton/runtime/jit.py#L514) used by the JIT cache are not used by triton-dejavu. 
 
 
 #### Example
@@ -190,26 +190,26 @@ Please note that smac depends on [swig](https://www.swig.org), which need to be 
 
 ### JITCache
 
-The launch overhead of triton kernels is a well known problem (see e.g. [1](https://github.com/triton-lang/triton/pull/3503), [2](https://github.com/triton-lang/triton/issues/2637), [3](https://github.com/triton-lang/triton/issues/6064)). Parts of the launch overhead comes from the fact that the triton JIT checks very carefully if an existing binary is safe to use. 
+The launch overhead of triton kernels is a well known problem (see e.g. [1](https://github.com/triton-lang/triton/pull/3503), [2](https://github.com/triton-lang/triton/issues/2637), [3](https://github.com/triton-lang/triton/issues/6064)). Parts of the launch overhead comes from the fact that the triton JIT checks very carefully if an existing binary is safe to use.
 
-In many scenarios, these checks can be relaxed. Such a cache with relaxed checks is implemented by `triton_dejavu.jitcache`. It is implemented as a decorator that could be used in front of the `triton.jit` decorator: 
+In many scenarios, these checks can be relaxed. Such a cache with relaxed checks is implemented by `triton_dejavu.jitcache`. It is implemented as a decorator that could be used in front of the `triton.jit` decorator:
 
 ```
 @triton_dejavu.jitcache(
     check_keys=["x", "BLOCK_SIZE", "USE_ALIBI_SLOPES", "SLIDING_WINDOW", "filter_by_query_len"],
 )
 @triton.jit
-def kernel_paged_attention_.... 
+def kernel_paged_attention_...
 ```
 
-The required `check_keys` argument must provide a list of the kernel parameters marked as `tl.constexpr` that **must be checked** to select the correct kernel binary. Ideally, this is just a subset of all constant kernel parameters.  
-For example, if we have two constant parameters A and B, but we know that A never will change in a particular application, but B will, then the list should look like `check_keys=["A"]`. 
+The required `check_keys` argument must provide a list of the kernel parameters marked as `tl.constexpr` that **must be checked** to select the correct kernel binary. Ideally, this is just a subset of all constant kernel parameters.
+For example, if we have two constant parameters A and B, but we know that A never will change in a particular application, but B will, then the list should look like `check_keys=["A"]`.
 
-Consequently, *the usage of `triton_dejavu.jitcache` is application specific* (and also *experimental*). 
+Consequently, *the usage of `triton_dejavu.jitcache` is application specific* (and also *experimental*).
 
-Additionally, a user could provide a lock with e.g. `cache_lock=triton_dejavu.global_cache_lock` to ensure that no re-compilation happens after the cache lock is locked. 
+Additionally, a user could provide a lock with e.g. `cache_lock=triton_dejavu.global_cache_lock` to ensure that no re-compilation happens after the cache lock is locked.
 
-The `triton_dejavu.jitcache` reduces the launch overhead of triton kernels to 30-40 micro-seconds. 
+The `triton_dejavu.jitcache` reduces the launch overhead of triton kernels to 30-40 micro-seconds.
 
 
 Compatibility

--- a/triton_dejavu/__init__.py
+++ b/triton_dejavu/__init__.py
@@ -20,3 +20,4 @@ __version__ = "0.7.2"
 
 from .dejavu_storage import global_dejavu_storage
 from .autotuner import autotune, ConfigSpace
+from .jit_cache import jitcache, global_cache_lock

--- a/triton_dejavu/__init__.py
+++ b/triton_dejavu/__init__.py
@@ -15,7 +15,7 @@
 #  *******************************************************************************/
 #
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 
 from .dejavu_storage import global_dejavu_storage

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -60,7 +60,7 @@ global_cache_lock = CacheLock("global")
 class PreparedKernel:
     def __init__(
         self,
-        grid,
+        # grid,
         kernel,
         launch_metadata,
         launch_enter_hook,
@@ -70,12 +70,14 @@ class PreparedKernel:
         device,
         stream,
     ):
-        self.grid_obj = grid
+        # self.grid_obj = grid
         self.kernel = kernel
         self.launch_metadata = launch_metadata
         self.launch_enter_hook = launch_enter_hook
         self.launch_exit_hook = launch_exit_hook
         self.non_const_arg_names = non_const_arg_names
+        if flag_print_debug_verbose:
+            print(self.non_const_arg_names)
 
         self.cache_key = cache_key
         # TODO: safe to cache?
@@ -90,10 +92,15 @@ class PreparedKernel:
         for arg_n in self.non_const_arg_names:
             non_constsexpr_vals.append(kwargs[arg_n])
 
-        if callable(self.grid_obj):
-            grid = self.grid_obj(kwargs)
+        # grid can't be cached
+        if callable(kwargs["grid"]):
+            grid = kwargs["grid"](kwargs)
         else:
-            grid = self.grid_obj
+            grid = kwargs["grid"]
+        # if callable(self.grid_obj):
+        #     grid = self.grid_obj(kwargs)
+        # else:
+        #     grid = self.grid_obj
         grid_size = len(grid)
         grid_0 = grid[0]
         grid_1 = grid[1] if grid_size > 1 else 1
@@ -182,7 +189,7 @@ class JitCache(KernelInterface):
         launch_metadata = kernel.launch_metadata(grid, stream, *non_constexpr_vals)
 
         prepared_kernel = PreparedKernel(
-            grid,
+            # grid,
             kernel,
             launch_metadata,
             self.fn.CompiledKernel.launch_enter_hook,

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -1,0 +1,297 @@
+#  /*******************************************************************************
+#   * Copyright 2025 IBM Corporation
+#   *
+#   * Licensed under the Apache License, Version 2.0 (the "License");
+#   * you may not use this file except in compliance with the License.
+#   * You may obtain a copy of the License at
+#   *
+#   *     http://www.apache.org/licenses/LICENSE-2.0
+#   *
+#   * Unless required by applicable law or agreed to in writing, software
+#   * distributed under the License is distributed on an "AS IS" BASIS,
+#   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   * See the License for the specific language governing permissions and
+#   * limitations under the License.
+#  *******************************************************************************/
+#
+
+from __future__ import annotations
+
+import builtins
+import sys
+import os
+import time
+import inspect
+from typing import Dict
+import itertools
+import torch
+import copy
+
+# TODO: still necessary?
+# import gc
+# import traceback
+
+# from triton.testing import do_bench, do_bench_cudagraph
+from triton_dejavu.testing import do_bench, KernelEvalCall
+from triton import KernelInterface, Config, OutOfResources, CompilationError
+from triton.runtime.driver import driver
+
+from triton import __version__ as triton_version
+
+triton_major_version = int(triton_version.split(".")[0])
+
+from triton_dejavu.dejavu_storage import (
+    global_dejavu_storage,
+    get_config_list_hash,
+    get_list_hash,
+    get_string_hash,
+)
+from triton_dejavu.dejavu_utilities import (
+    get_triton_config_parameter_names,
+    get_triton_config_defaults_values,
+    get_triton_config_defaults_types,
+    flag_print_debug,
+    flag_print_autotuning,
+    flag_print_debug_verbose,
+    get_type_dict,
+)
+from triton_dejavu.cache_manager import set_triton_cache_manager
+from triton_dejavu.utils import global_metadata_store
+from triton_dejavu.testing import SerializeableCompiledKernel, CompiledKernelRun
+
+
+global_cache_lock = False
+
+
+class PreparedKernel:
+    def __init__(self, grid, kernel, launch_metadata, launch_enter_hook, launch_exit_hook, arg_names, non_const_arg_names):
+        self.grid_obj = grid
+        self.kernel = kernel
+        self.launch_metadata = launch_metadata
+        self.launch_enter_hook = launch_enter_hook
+        self.launch_exit_hook = launch_exit_hook
+        # self.arg_names = arg_names
+        self.non_const_arg_names = non_const_arg_names
+        # self.non_const_arg_index = {}
+
+    
+    def __call__(self, *args, **kwargs):
+        assert len(args) == 0
+
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+
+        non_constsexpr_vals = []
+        # order should be the same...
+        for arg_n in self.non_const_arg_names:
+            non_constsexpr_vals.append(kwargs[arg_n])
+
+        if callable(self.grid_obj):
+            grid = self.grid_obj(kwargs)
+        else:
+            grid = self.grid_obj
+        grid_size = len(grid)
+        grid_0 = grid[0]
+        grid_1 = grid[1] if grid_size > 1 else 1
+        grid_2 = grid[2] if grid_size > 2 else 1
+
+        return self.kernel.run(
+            grid_0,
+            grid_1,
+            grid_2,
+            stream,
+            self.kernel.function,
+            self.kernel.packed_metadata,
+            self.launch_metadata,
+            self.launch_enter_hook,
+            self.launch_exit_hook,
+            *non_constsexpr_vals,
+        )
+
+
+class JitCache(KernelInterface):
+
+    def __init__(
+            self, fn, arg_names,
+    cache_lock,
+    check_keys,    
+    ):
+        self.arg_names = arg_names
+        self.fn = fn
+        self.base_fn = fn
+        while not inspect.isfunction(self.base_fn):
+            self.base_fn = self.base_fn.fn
+        self.cache_lock = cache_lock
+        self.check_keys = check_keys
+        self.kernel_cache = {}
+    
+    def _call_config_pre_hook(self, *args, config, **kwargs):
+        # must be done before binding...so not separated...
+        pre_hook = config.pre_hook if config.pre_hook else None
+        if not pre_hook:
+            return
+        print(f"[triton-dejavu] Executing pre_hook of config {config}...")
+        prehook_start = time.time()
+        nargs = dict(zip(self.arg_names, args))
+        full_nargs = {**nargs, **kwargs}
+        pre_hook(full_nargs)
+        prehook_end = time.time()
+        prehook_duration = prehook_end - prehook_start
+        print(f"\t...pre_hook done ({prehook_duration}s).")
+
+    def _get_prepared_kernel(self, *args, **kwargs) -> PreparedKernel:
+        
+        kwargs["warmup"] = True
+        compile_start = time.time()
+        kernel = self.fn.run(*args, **kwargs)
+        compile_end = time.time()
+
+        const_arg_names = []
+        non_const_arg_names = []
+        for p in self.fn.params:
+            if p.is_constexpr or p.is_const:
+                const_arg_names.append(p.name)
+            else:
+                non_const_arg_names.append(p.name)
+
+        (
+            bound_args,
+            sig_and_spec,
+            constexpr_vals,
+            non_constexpr_vals,
+            excess_kwargs,
+        ) = self.fn.binder(*args, **kwargs)
+        bind_end = time.time()
+
+        if callable(kwargs["grid"]):
+            grid = kwargs["grid"](kwargs)
+        else:
+            grid = kwargs["grid"]
+        
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+        launch_metadata = kernel.launch_metadata(
+            grid, stream, *non_constexpr_vals
+        )
+
+        prepared_kernel = PreparedKernel(grid, kernel, launch_metadata,
+            self.fn.CompiledKernel.launch_enter_hook,
+            self.fn.CompiledKernel.launch_exit_hook,
+            self.arg_names,
+            non_const_arg_names)
+        
+        wrapper_end = time.time()
+        compile_time = compile_end - compile_start
+        bind_time = bind_end - compile_end
+        wrapper_time = wrapper_end - bind_end
+
+        if flag_print_debug:
+            print(
+                f"[triton-dejavu] JIT compilation took {compile_time}s, binding {bind_time}, wrapper {wrapper_time}s."
+            )
+
+        return prepared_kernel 
+
+    def run(self, *args, **kwargs):
+        # TODO: extract config? 
+        # current = dict(kwargs, **config.all_kwargs())
+
+        # we only support kwargs
+        assert len(args) == 0
+
+        # compiled_kernel = self.get_compiled_run_version(*args, **kwargs)
+        # ret = self.fn.run(*args, **kwargs)
+        # return ret
+
+        prepared_kernel = self._get_prepared_kernel(*args, **kwargs)
+
+        # self.kernel_cache['none'] = prepared_kernel
+        return prepared_kernel(*args, **kwargs)
+
+    
+    def get_compiled_run_version(self, *args, **kwargs) -> CompiledKernelRun:
+        # need to call config pre-hook first...
+        # self._call_config_pre_hook()
+
+        # self.current["warmup"] = True
+        kwargs["warmup"] = True
+        compile_start = time.time()
+        kernel = self.fn.run(*args, **kwargs)
+        compile_end = time.time()
+
+        const_arg_names = []
+        non_const_arg_names = []
+        for p in self.fn.params:
+            if p.is_constexpr or p.is_const:
+                const_arg_names.append(p.name)
+            else:
+                non_const_arg_names.append(p.name)
+
+        (
+            bound_args,
+            sig_and_spec,
+            constexpr_vals,
+            non_constexpr_vals,
+            excess_kwargs,
+        ) = self.fn.binder(*args, **kwargs)
+        bind_end = time.time()
+
+        if callable(kwargs["grid"]):
+            grid = kwargs["grid"](kwargs)
+        else:
+            grid = kwargs["grid"]
+        
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+        launch_metadata = kernel.launch_metadata(
+            grid, stream, *non_constexpr_vals
+        )
+
+        grid_size = len(grid)
+        grid_0 = grid[0]
+        grid_1 = grid[1] if grid_size > 1 else 1
+        grid_2 = grid[2] if grid_size > 2 else 1
+
+        # kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
+        #            self.fn.CompiledKernel.launch_enter_hook, self.fn.CompiledKernel.launch_exit_hook, *non_constexpr_vals)
+        compiled_kernel = CompiledKernelRun(
+            grid_0,
+            grid_1,
+            grid_2,
+            kernel,
+            launch_metadata,
+            self.fn.CompiledKernel.launch_enter_hook,
+            self.fn.CompiledKernel.launch_exit_hook,
+            *non_constexpr_vals,
+        )
+        wrapper_end = time.time()
+        compile_time = compile_end - compile_start
+        bind_time = bind_end - compile_end
+        wrapper_time = wrapper_end - bind_end
+
+        if flag_print_debug:
+            print(
+                f"[triton-dejavu] JIT compilation took {compile_time}s, binding {bind_time}, wrapper {wrapper_time}s."
+            )
+
+        return compiled_kernel
+
+
+def jitcache(
+    cache_lock,
+    check_keys,    
+):
+    """
+    Decorator for caching a :code:`triton.jit`'d function.
+    
+    """
+
+    def decorator(fn):
+        return JitCache(
+            fn,
+            fn.arg_names,
+            cache_lock,
+            check_keys,
+        )
+    
+    return decorator

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -216,14 +216,22 @@ class JitCache(KernelInterface):
             if prepared_kernel.get_key() in self.kernel_cache and flag_print_debug:
                 # raise RuntimeError("Kernel variant already cached. This means the given check_keys are ambigous.")
                 print(
-                    "[triton-dejavu] WARNING: Kernel variant already cached, will override. "
+                    "[triton-dejavu:JitCache] WARNING: Kernel variant already cached, will override. "
                     "This could mean that the given check_keys are ambigous (or the same call was already executed)."
                 )
             self.kernel_cache[prepared_kernel.get_key()] = prepared_kernel
 
         # TODO: if the cache index is not present, it will create an exception
         #  should we instead then compile it?
-        kernel_variant = self.kernel_cache[self.cache_index_func(kwargs)]
+        try:
+            kernel_variant = self.kernel_cache[self.cache_index_func(kwargs)]
+        except KeyError as e:
+            print(
+                f"[triton-dejavu:JitCache] ERROR: Key {self.cache_index_func(kwargs)}  not in cache.\n"
+                f"Current cache: {list(self.kernel_cache.keys())}"
+            )
+            print(e)
+            raise e
 
         return kernel_variant(*args, **kwargs)
 

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -213,6 +213,12 @@ class JitCache(KernelInterface):
             for key in self.check_keys:
                 assert type(kwargs[key]) in [int, bool, float]
             prepared_kernel = self._get_prepared_kernel(*args, **kwargs)
+            if prepared_kernel.get_key() in self.kernel_cache and flag_print_debug:
+                # raise RuntimeError("Kernel variant already cached. This means the given check_keys are ambigous.")
+                print(
+                    "[triton-dejavu] WARNING: Kernel variant already cached, will override. "
+                    "This could mean that the given check_keys are ambigous (or the same call was already executed)."
+                )
             self.kernel_cache[prepared_kernel.get_key()] = prepared_kernel
 
         # TODO: if the cache index is not present, it will create an exception

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -17,66 +17,44 @@
 
 from __future__ import annotations
 
-import builtins
 import sys
 import os
 import time
 import inspect
-from typing import Dict
-import itertools
-import torch
-import copy
 
-# TODO: still necessary?
-# import gc
-# import traceback
-
-# from triton.testing import do_bench, do_bench_cudagraph
-from triton_dejavu.testing import do_bench, KernelEvalCall
-from triton import KernelInterface, Config, OutOfResources, CompilationError
+from triton import KernelInterface
 from triton.runtime.driver import driver
 
 from triton import __version__ as triton_version
 
 triton_major_version = int(triton_version.split(".")[0])
 triton_minor_version = int(triton_version.split(".")[1])
-triton_version_float = triton_major_version + float(triton_minor_version/10)
+triton_version_float = triton_major_version + float(triton_minor_version / 10)
 
-
-from triton_dejavu.dejavu_storage import (
-    global_dejavu_storage,
-    get_config_list_hash,
-    get_list_hash,
-    get_string_hash,
-)
 from triton_dejavu.dejavu_utilities import (
-    get_triton_config_parameter_names,
-    get_triton_config_defaults_values,
-    get_triton_config_defaults_types,
     flag_print_debug,
-    flag_print_autotuning,
     flag_print_debug_verbose,
-    get_type_dict,
 )
-from triton_dejavu.cache_manager import set_triton_cache_manager
-from triton_dejavu.utils import global_metadata_store
-from triton_dejavu.testing import SerializeableCompiledKernel, CompiledKernelRun
 
 
 class CacheLock:
 
-    def __init__(self):
+    def __init__(self, id="unkown"):
         self.is_locked = False
+        self.id = id
 
     def lock(self):
         self.is_locked = True
-        # print("cache lock is locked")
+        if flag_print_debug_verbose:
+            print(f"[triton-dejavu] JitCache lock '{self.id}' is LOCKED.")
 
     def unlock(self):
         self.is_locked = False
+        if flag_print_debug_verbose:
+            print(f"[triton-dejavu] JitCache lock '{self.id}' is UNLOCKED.")
 
 
-global_cache_lock = CacheLock()
+global_cache_lock = CacheLock("global")
 
 
 class PreparedKernel:
@@ -87,27 +65,18 @@ class PreparedKernel:
         launch_metadata,
         launch_enter_hook,
         launch_exit_hook,
-        arg_names,
         non_const_arg_names,
         cache_key,
-        # check_keys,
-        # current_kwargs,
         device,
-        stream
+        stream,
     ):
         self.grid_obj = grid
         self.kernel = kernel
         self.launch_metadata = launch_metadata
         self.launch_enter_hook = launch_enter_hook
         self.launch_exit_hook = launch_exit_hook
-        # self.arg_names = arg_names
         self.non_const_arg_names = non_const_arg_names
-        # self.keys_for_cache_index = check_keys
-        # self.non_const_arg_index = {
-        # cache_key = ''
-        # for c_arg_name in check_keys:
-        #     cache_key += str(current_kwargs[c_arg_name])
-        # # self.cache_key = 'should-be-random-string'
+
         self.cache_key = cache_key
         # TODO: safe to cache?
         self.device = device
@@ -116,11 +85,8 @@ class PreparedKernel:
     def __call__(self, *args, **kwargs):
         assert len(args) == 0
 
-        # device = driver.active.get_current_device()
-        # stream = driver.active.get_current_stream(device)
-
         non_constsexpr_vals = []
-        # order should be the same...
+        # order is always the same...
         for arg_n in self.non_const_arg_names:
             non_constsexpr_vals.append(kwargs[arg_n])
 
@@ -145,10 +111,6 @@ class PreparedKernel:
             self.launch_exit_hook,
             *non_constsexpr_vals,
         )
-
-    # def get_deps_tree(self):
-    #     # TODO: maybe make a dict for each check key
-    #     return None
 
     def get_key(self):
         return self.cache_key
@@ -180,20 +142,6 @@ class JitCache(KernelInterface):
             return cache_key
 
         self.cache_index_func = calc_cache_index
-
-    # def _call_config_pre_hook(self, *args, config, **kwargs):
-    #     # must be done before binding...so not separated...
-    #     pre_hook = config.pre_hook if config.pre_hook else None
-    #     if not pre_hook:
-    #         return
-    #     print(f"[triton-dejavu] Executing pre_hook of config {config}...")
-    #     prehook_start = time.time()
-    #     nargs = dict(zip(self.arg_names, args))
-    #     full_nargs = {**nargs, **kwargs}
-    #     pre_hook(full_nargs)
-    #     prehook_end = time.time()
-    #     prehook_duration = prehook_end - prehook_start
-    #     print(f"\t...pre_hook done ({prehook_duration}s).")
 
     def _get_prepared_kernel(self, *args, **kwargs) -> PreparedKernel:
 
@@ -234,11 +182,8 @@ class JitCache(KernelInterface):
             launch_metadata,
             self.fn.CompiledKernel.launch_enter_hook,
             self.fn.CompiledKernel.launch_exit_hook,
-            self.arg_names,
             non_const_arg_names,
             self.cache_index_func(kwargs),
-            # self.check_keys,
-            # kwargs,
             device,
             stream,
         )
@@ -260,10 +205,10 @@ class JitCache(KernelInterface):
         assert len(args) == 0
         # assert no config pre-hook
         assert "pre_hook" not in kwargs or kwargs["pre_hook"] is None
-        
+
         # print(f"my lock: {self.cache_lock.is_locked}")
         # TODO ?: or len(self.kernel_cache) == 0:
-        if not self.cache_lock.is_locked: 
+        if not self.cache_lock.is_locked:
             # we only support int, bool, float as cache index
             for key in self.check_keys:
                 assert type(kwargs[key]) in [int, bool, float]
@@ -271,75 +216,10 @@ class JitCache(KernelInterface):
             self.kernel_cache[prepared_kernel.get_key()] = prepared_kernel
 
         # TODO: if the cache index is not present, it will create an exception
-        #  should we instead then compile it? 
+        #  should we instead then compile it?
         kernel_variant = self.kernel_cache[self.cache_index_func(kwargs)]
 
         return kernel_variant(*args, **kwargs)
-
-    # def get_compiled_run_version(self, *args, **kwargs) -> CompiledKernelRun:
-    #     # need to call config pre-hook first...
-    #     # self._call_config_pre_hook()
-
-    #     # self.current["warmup"] = True
-    #     kwargs["warmup"] = True
-    #     compile_start = time.time()
-    #     kernel = self.fn.run(*args, **kwargs)
-    #     compile_end = time.time()
-
-    #     const_arg_names = []
-    #     non_const_arg_names = []
-    #     for p in self.fn.params:
-    #         if p.is_constexpr or p.is_const:
-    #             const_arg_names.append(p.name)
-    #         else:
-    #             non_const_arg_names.append(p.name)
-
-    #     (
-    #         bound_args,
-    #         sig_and_spec,
-    #         constexpr_vals,
-    #         non_constexpr_vals,
-    #         excess_kwargs,
-    #     ) = self.fn.binder(*args, **kwargs)
-    #     bind_end = time.time()
-
-    #     if callable(kwargs["grid"]):
-    #         grid = kwargs["grid"](kwargs)
-    #     else:
-    #         grid = kwargs["grid"]
-
-    #     device = driver.active.get_current_device()
-    #     stream = driver.active.get_current_stream(device)
-    #     launch_metadata = kernel.launch_metadata(grid, stream, *non_constexpr_vals)
-
-    #     grid_size = len(grid)
-    #     grid_0 = grid[0]
-    #     grid_1 = grid[1] if grid_size > 1 else 1
-    #     grid_2 = grid[2] if grid_size > 2 else 1
-
-    #     # kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
-    #     #            self.fn.CompiledKernel.launch_enter_hook, self.fn.CompiledKernel.launch_exit_hook, *non_constexpr_vals)
-    #     compiled_kernel = CompiledKernelRun(
-    #         grid_0,
-    #         grid_1,
-    #         grid_2,
-    #         kernel,
-    #         launch_metadata,
-    #         self.fn.CompiledKernel.launch_enter_hook,
-    #         self.fn.CompiledKernel.launch_exit_hook,
-    #         *non_constexpr_vals,
-    #     )
-    #     wrapper_end = time.time()
-    #     compile_time = compile_end - compile_start
-    #     bind_time = bind_end - compile_end
-    #     wrapper_time = wrapper_end - bind_end
-
-    #     if flag_print_debug:
-    #         print(
-    #             f"[triton-dejavu] JIT compilation took {compile_time}s, binding {bind_time}, wrapper {wrapper_time}s."
-    #         )
-
-    #     return compiled_kernel
 
 
 def jitcache(
@@ -349,6 +229,10 @@ def jitcache(
     """
     Decorator for caching a :code:`triton.jit`'d function.
 
+    :param cache_lock: The CacheLock used for this JitCache.
+    :type cache_lock: CacheLock
+    :param check_keys: The list of tl.constexpr that are used to index the cache. Only types int, bool, float are supported.
+    :type check_keys: list[str]
     """
 
     def decorator(fn):


### PR DESCRIPTION
The launch overhead of triton kernels is a well known problem (see e.g. [1](https://github.com/triton-lang/triton/pull/3503), [2](https://github.com/triton-lang/triton/issues/2637), [3](https://github.com/triton-lang/triton/issues/6064)). Parts of the launch overhead comes from the fact that the triton JIT checks very carefully if an existing binary is safe to use. 

In many scenarios, these checks can be relaxed. 
This PR adds such a cache with relaxed checks is implemented by `triton_dejavu.jitcache`. It is implemented as a decorator that could be used in front of the `triton.jit` decorator: 

```
@triton_dejavu.jitcache(
    check_keys=["x", "BLOCK_SIZE", "USE_ALIBI_SLOPES", "SLIDING_WINDOW", "filter_by_query_len"],
)
@triton.jit
def kernel_paged_attention_.... 
```

Details see Readme. 