### PR TITLE
Improvements to JitCache (assume const)

### DIFF
--- a/triton_dejavu/autotuner.py
+++ b/triton_dejavu/autotuner.py
@@ -384,7 +384,7 @@ class Autotuner(KernelInterface):
         if os.getenv("TRITON_DEJAVU_HASH_SEARCH_PARAMS", "1") == "1":
             hs += f" use_bo {self.use_bo} use_random {self.use_random_search} max_search_n {self.search_max_n_trials} max_search_t {self.max_search_time_s}"
         # TODO: how to hash the custom hooks?
-        #  inspect cant find it, possible would be str(inspect.Signature().from_callable(self.pre_hook))
+        #  inspect can't find it, possible would be str(inspect.Signature().from_callable(self.pre_hook))
         #  maybe not relevant since should not influence the autotuner result
         h = get_string_hash(hs)
         return h
@@ -430,7 +430,7 @@ class Autotuner(KernelInterface):
                 **current,
             )
             # NOTE: if a config.pre_hook exists, it will be executed in the parent process
-            #  but with already cloned arges (not possible to pickle an unbound kernel)
+            #  but with already cloned args (not possible to pickle an unbound kernel)
             bench_res = do_bench(
                 kernel_call_obj,
                 use_cuda_graphs=self.use_cuda_graph,
@@ -698,7 +698,7 @@ class Autotuner(KernelInterface):
                 **kwargs,
             )
         else:
-            # FIXME: this could assing the wrong argument to the wrong name if autotuner args are not last!
+            # FIXME: this could assign the wrong argument to the wrong name if autotuner args are not last!
             self.nargs = dict(zip(self.arg_names, args))
             used_cached_result = True
             self.bench_time = 0.0
@@ -953,7 +953,7 @@ def autotune(
     :type search_max_repeat: int
     :param quantiles: 3-tuple for the quantiles that are reported of the evaluation function, e.g. (0.5, 0.2, 0.8).
                         Default is `None` which will lead to the median (0.5 quantile).
-    :param metadata_key: String to store the found configration as metadata in the triton_dejavu.utils.global_metadata_store.
+    :param metadata_key: String to store the found configuration as metadata in the triton_dejavu.utils.global_metadata_store.
                          This could be used in combination with metadata_fn and proton.
     :type metadata_key: str
     :param custom_data_storage: Absolute path to a custom triton-dejavu data location for this function.
@@ -994,7 +994,7 @@ def autotune(
 class ConfigSpace:
     """
     An object to represent the space of possible kernel configurations for the auto-tuner to evaluate.
-    At the initalization of the autotuner, a list of all possible and valid configurations is generated
+    At the initialization of the autotuner, a list of all possible and valid configurations is generated
     and passed to the autotuner.
 
     Please note that some of the configuration parameters depend on the used triton config.

--- a/triton_dejavu/dejavu_storage.py
+++ b/triton_dejavu/dejavu_storage.py
@@ -263,7 +263,7 @@ class DejavuStorage:
         for key, config in cache.items():
             if str(key) in cache_json["cache"]:
                 continue
-            # compatability with cuda stream feature of triton 3
+            # compatibility with cuda stream feature of triton 3
             vals = timings[key]
             if type(vals) is not list:
                 vals = [vals]

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -93,9 +93,7 @@ class PreparedKernel:
         self.launch_exit_hook = launch_exit_hook
         self.non_const_arg_names = non_const_arg_names
 
-        # TODO: safe to cache?
         self.device = device
-        self.stream = stream
         self._init_handles()
 
         if flag_print_debug_verbose:
@@ -123,7 +121,6 @@ class PreparedKernel:
             raise OutOfResources(
                 self.metadata.shared, self.dev_max_shared, "shared memory"
             )
-        # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
         self.module, self.function, self.n_regs, self.n_spills = (
             driver.active.utils.load_binary(
                 self.kernel.name,
@@ -154,12 +151,14 @@ class PreparedKernel:
             grid_0 = grid[0]
             grid_1 = grid[1] if grid_size > 1 else 1
             grid_2 = grid[2] if grid_size > 2 else 1
+                
+        stream = driver.active.get_current_stream(self.device)
 
         return self.run(
             grid_0,
             grid_1,
             grid_2,
-            self.stream,
+            stream,
             self.function,
             self.kernel.packed_metadata,
             self.launch_metadata,

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -140,7 +140,9 @@ class PreparedKernel:
             )
         )
         if flag_print_debug_verbose:
-            print(f"kernel initalized: {self.n_regs}, {self.n_spills}, {self.function}")
+            print(
+                f"kernel initialized: {self.n_regs}, {self.n_spills}, {self.function}"
+            )
 
     def __call__(self, *args, **kwargs):
         assert len(args) == 0
@@ -330,7 +332,6 @@ class JitCache(KernelInterface):
                     )
             prepared_kernel = self._get_prepared_kernel(*args, **kwargs)
             if prepared_kernel.get_key() in self.kernel_cache and flag_print_debug:
-                # raise RuntimeError("Kernel variant already cached. This means the given check_keys are ambigous.")
                 print(
                     f"[{__print_name__}:JitCache] WARNING: Kernel variant already cached, will override (cache lock is not locked). "
                     f"This could mean that the given check_keys are ambiguous (or the same call was already executed)."

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -42,7 +42,7 @@ __print_name__ = "triton-dejavu"
 
 class CacheLock:
 
-    def __init__(self, id="unkown"):
+    def __init__(self, id="unknown"):
         self.is_locked = False
         self.id = id
 
@@ -71,9 +71,10 @@ class PreparedKernel:
         launch_enter_hook,
         launch_exit_hook,
         non_const_arg_names,
+        assume_const_vals_dict,
+        update_only_arg_names,
         cache_key,
         device,
-        stream,
     ):
         self.grid_obj = grid_obj
         self.grid_is_callable = callable(grid_obj)
@@ -91,7 +92,16 @@ class PreparedKernel:
         self.launch_metadata = launch_metadata
         self.launch_enter_hook = launch_enter_hook
         self.launch_exit_hook = launch_exit_hook
+
         self.non_const_arg_names = non_const_arg_names
+        self.non_const_vals_lst = []
+        self.update_args_index = {}
+        for i, arg_n in enumerate(self.non_const_arg_names):
+            if arg_n in update_only_arg_names:
+                self.update_args_index[arg_n] = i
+                self.non_const_vals_lst.append('dummy_value')
+            else:
+                self.non_const_vals_lst.append(assume_const_vals_dict[arg_n])
 
         self.device = device
         self._init_handles()
@@ -135,10 +145,12 @@ class PreparedKernel:
     def __call__(self, *args, **kwargs):
         assert len(args) == 0
 
-        non_constsexpr_vals = []
-        # order is always the same...
-        for arg_n in self.non_const_arg_names:
-            non_constsexpr_vals.append(kwargs[arg_n])
+        # non_constsexpr_vals = []
+        # # order is always the same...
+        # for arg_n in self.non_const_arg_names:
+        #     non_constsexpr_vals.append(kwargs[arg_n])
+        for arg_n, idx in self.update_args_index.items():
+            self.non_const_vals_lst[idx] = kwargs[arg_n]
 
         if self.cache_launch_grid:
             grid_0, grid_1, grid_2 = self.concrete_grid
@@ -164,7 +176,8 @@ class PreparedKernel:
             self.launch_metadata,
             self.launch_enter_hook,
             self.launch_exit_hook,
-            *non_constsexpr_vals,
+            # *non_constsexpr_vals,
+            *self.non_const_vals_lst,
         )
 
     def get_key(self):
@@ -180,6 +193,7 @@ class JitCache(KernelInterface):
         check_keys,
         cache_lock: CacheLock,
         cache_launch_grid=False,
+        assume_const=None,
     ):
         assert 3.0 <= triton_version_float <= 3.2
         self.arg_names = arg_names
@@ -195,6 +209,7 @@ class JitCache(KernelInterface):
             self.dynamic_mode = True
             self.run = self._run_dynamic
         self.check_keys = check_keys
+        self.assume_const = assume_const
         self.kernel_cache = {}
 
         def calc_cache_index(kwargs):
@@ -227,8 +242,19 @@ class JitCache(KernelInterface):
                 non_const_arg_names.append(p.name)
         if any(x in self.check_keys for x in non_const_arg_names):
             raise RuntimeError(
-                f"[{__print_name__}] ERROR: check_keys must only contain parameters marked as tl.constexpr (non-constants will be updated in all cases)."
-            )
+                f"[{__print_name__}] ERROR: check_keys must only contain"
+                "parameters marked as tl.constexpr (non-constants will be "
+                "updated in all cases).")
+        if self.assume_const:
+            if any(x in self.assume_const for x in const_arg_names):
+                raise RuntimeError(
+                    f"[{__print_name__}] ERROR: assume_const must only contain"
+                    "parameters NOT marked as tl.constexpr.")
+            update_only_arg_names = [arg_n for arg_n in non_const_arg_names if arg_n not in self.assume_const]
+            assume_const_vals_dict = {arg_n: kwargs[arg_n] for arg_n in non_const_arg_names if arg_n in self.assume_const}
+        else:
+            update_only_arg_names = non_const_arg_names
+            assume_const_vals_dict = {}
 
         (
             bound_args,
@@ -257,9 +283,10 @@ class JitCache(KernelInterface):
             self.fn.CompiledKernel.launch_enter_hook,
             self.fn.CompiledKernel.launch_exit_hook,
             non_const_arg_names,
+            assume_const_vals_dict,
+            update_only_arg_names,
             self.cache_index_func(kwargs),
             device,
-            stream,
         )
 
         wrapper_end = time.time()
@@ -293,7 +320,7 @@ class JitCache(KernelInterface):
                 # raise RuntimeError("Kernel variant already cached. This means the given check_keys are ambigous.")
                 print(
                     f"[{__print_name__}:JitCache] WARNING: Kernel variant already cached, will override (cache lock is not locked). "
-                    f"This could mean that the given check_keys are ambigous (or the same call was already executed)."
+                    f"This could mean that the given check_keys are ambiguous (or the same call was already executed)."
                 )
             self.kernel_cache[prepared_kernel.get_key()] = prepared_kernel
 
@@ -339,16 +366,23 @@ def jitcache(
     check_keys,
     cache_lock=None,
     cache_launch_grid=False,
+    assume_const=None,
 ):
     """
     Decorator for caching a :code:`triton.jit`'d function.
 
-    :param check_keys: The list of tl.constexpr that are used to index the cache. Only types int, bool, float are supported.
+    :param check_keys: The list of tl.constexpr that are used to index
+                       the cache. Only types int, bool, float are supported.
     :type check_keys: list[str]
     :param cache_lock: The CacheLock used for this JitCache.
     :type cache_lock: CacheLock
-    :param chache_launch_grid: Indicate if the launch grid size is static and should be cached (False by default).
+    :param chache_launch_grid: Indicate if the launch grid size is static and
+                               should be cached (False by default).
     :type cache_launch_grid: bool
+    :param assume_const: A list of parameters that are NOT marked as
+                         tl.constexpr but should be treated as constants in
+                         this kernel launch.
+    :param assume_const: list[str]
     """
 
     def decorator(fn):
@@ -358,6 +392,7 @@ def jitcache(
             check_keys,
             cache_lock,
             cache_launch_grid,
+            assume_const,
         )
 
     return decorator

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -99,7 +99,7 @@ class PreparedKernel:
         for i, arg_n in enumerate(self.non_const_arg_names):
             if arg_n in update_only_arg_names:
                 self.update_args_index[arg_n] = i
-                self.non_const_vals_lst.append('dummy_value')
+                self.non_const_vals_lst.append("dummy_value")
             else:
                 self.non_const_vals_lst.append(assume_const_vals_dict[arg_n])
 
@@ -163,7 +163,7 @@ class PreparedKernel:
             grid_0 = grid[0]
             grid_1 = grid[1] if grid_size > 1 else 1
             grid_2 = grid[2] if grid_size > 2 else 1
-                
+
         stream = driver.active.get_current_stream(self.device)
 
         return self.run(
@@ -244,14 +244,22 @@ class JitCache(KernelInterface):
             raise RuntimeError(
                 f"[{__print_name__}] ERROR: check_keys must only contain"
                 "parameters marked as tl.constexpr (non-constants will be "
-                "updated in all cases).")
+                "updated in all cases)."
+            )
         if self.assume_const:
             if any(x in self.assume_const for x in const_arg_names):
                 raise RuntimeError(
                     f"[{__print_name__}] ERROR: assume_const must only contain"
-                    "parameters NOT marked as tl.constexpr.")
-            update_only_arg_names = [arg_n for arg_n in non_const_arg_names if arg_n not in self.assume_const]
-            assume_const_vals_dict = {arg_n: kwargs[arg_n] for arg_n in non_const_arg_names if arg_n in self.assume_const}
+                    "parameters NOT marked as tl.constexpr."
+                )
+            update_only_arg_names = [
+                arg_n for arg_n in non_const_arg_names if arg_n not in self.assume_const
+            ]
+            assume_const_vals_dict = {
+                arg_n: kwargs[arg_n]
+                for arg_n in non_const_arg_names
+                if arg_n in self.assume_const
+            }
         else:
             update_only_arg_names = non_const_arg_names
             assume_const_vals_dict = {}
@@ -314,7 +322,12 @@ class JitCache(KernelInterface):
         if not self.cache_lock.is_locked:
             # we only support int, bool, float as cache index
             for key in self.check_keys:
-                assert type(kwargs[key]) in [int, bool, float]
+                if type(kwargs[key]) not in [int, bool, float, type(None)]:
+                    raise RuntimeError(
+                        f"[{__print_name__}] type of check_key {key} "
+                        f"{type(kwargs[key])} is not one of supported types: "
+                        f"int, bool float."
+                    )
             prepared_kernel = self._get_prepared_kernel(*args, **kwargs)
             if prepared_kernel.get_key() in self.kernel_cache and flag_print_debug:
                 # raise RuntimeError("Kernel variant already cached. This means the given check_keys are ambigous.")
@@ -355,7 +368,12 @@ class JitCache(KernelInterface):
                 )
             # we only support int, bool, float as cache index
             for key in self.check_keys:
-                assert type(kwargs[key]) in [int, bool, float]
+                if type(kwargs[key]) not in [int, bool, float, type(None)]:
+                    raise RuntimeError(
+                        f"[{__print_name__}] type of check_key {key} "
+                        f"{type(kwargs[key])} is not one of supported types: "
+                        f"int, bool float."
+                    )
             kernel_variant = self._get_prepared_kernel(*args, **kwargs)
             self.kernel_cache[kernel_variant.get_key()] = kernel_variant
 


### PR DESCRIPTION
This PR adds the `assume_const` feature to the JitCache. 

```
@triton_dejavu.jitcache(
    check_keys=["USE_ALIBI_SLOPES", "SLIDING_WINDOW", "filter_by_query_len"],
    assume_const=[
        "scale",
        "k_scale",
        "v_scale",
        "query_stride_1",
        "output_stride_1",
        "stride_k_cache_0",
        "stride_k_cache_1",
        "stride_k_cache_2",
        "stride_k_cache_4",
        "stride_v_cache_0",
        "stride_v_cache_1",
        "stride_v_cache_2",
        "stride_v_cache_2",
    ],
)
@triton.jit
def kernel_paged_attention_2d(
```

This is necessary in situations where some parameters are constant from the application PoV, but can't be declared `tl.constexpr`. This is for example the case with 64-bit addresses, which have to use `tl.int64`. 

Besides, it fixes some typos and extends the "documentation" in the Readme. 