### PR TITLE
Copy grid in caller

### DIFF
--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -21,6 +21,7 @@ import sys
 import os
 import time
 import inspect
+import copy
 
 from triton import KernelInterface
 from triton.runtime.driver import driver
@@ -149,7 +150,7 @@ class PreparedKernel:
             if self.grid_is_callable:
                 grid = kwargs["grid"](kwargs)
             else:
-                grid = kwargs["grid"]
+                grid = copy.deepcopy(kwargs["grid"])
             grid_size = len(grid)
             grid_0 = grid[0]
             grid_1 = grid[1] if grid_size > 1 else 1


### PR DESCRIPTION
I see strange behaviour related to the grid size, which only seems to be resolved either by explicitly calling `torch.cuda.synchronize` before calling the kernel, or by making this change inside deja-vu to deepcopy the grid. It's like the grid can change between entering this function and calling the kernel. 

Maybe there is a better solution...