### PR TITLE
fix reserved memory in combination with jitcache

### DIFF
--- a/triton_dejavu/autotuner.py
+++ b/triton_dejavu/autotuner.py
@@ -409,11 +409,9 @@ class Autotuner(KernelInterface):
             config.all_kwargs = lambda: _all_kwargs(config)
         current = dict(meta, **config.all_kwargs())
         full_nargs = {**self.nargs, **current}
-        
+
         if triton_major_version >= 3:
-            benchmarking_stream = (
-                torch.cuda.Stream() if self.use_cuda_graph else None
-            )
+            benchmarking_stream = torch.cuda.Stream() if self.use_cuda_graph else None
         else:
             benchmarking_stream = None
 

--- a/triton_dejavu/dejavu_storage.py
+++ b/triton_dejavu/dejavu_storage.py
@@ -18,7 +18,6 @@
 import sys
 import os
 import json
-import torch
 import triton
 import hashlib
 import time

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -42,7 +42,6 @@ __print_name__ = "triton-dejavu"
 
 
 class CacheLock:
-
     def __init__(self, id="unknown"):
         self.is_locked = False
         self.id = id
@@ -137,13 +136,16 @@ class PreparedKernel33:
             raise OutOfResources(
                 self.metadata.shared, self.dev_max_shared, "shared memory"
             )
-        self.module, self.function, self.n_regs, self.n_spills = (
-            driver.active.utils.load_binary(
-                self.kernel.name,
-                self.kernel.kernel,
-                self.kernel.metadata.shared,
-                self.device,
-            )
+        (
+            self.module,
+            self.function,
+            self.n_regs,
+            self.n_spills,
+        ) = driver.active.utils.load_binary(
+            self.kernel.name,
+            self.kernel.kernel,
+            self.kernel.metadata.shared,
+            self.device,
         )
         if flag_print_debug_verbose:
             print(
@@ -267,13 +269,16 @@ class PreparedKernel32:
             raise OutOfResources(
                 self.metadata.shared, self.dev_max_shared, "shared memory"
             )
-        self.module, self.function, self.n_regs, self.n_spills = (
-            driver.active.utils.load_binary(
-                self.kernel.name,
-                self.kernel.kernel,
-                self.kernel.metadata.shared,
-                self.device,
-            )
+        (
+            self.module,
+            self.function,
+            self.n_regs,
+            self.n_spills,
+        ) = driver.active.utils.load_binary(
+            self.kernel.name,
+            self.kernel.kernel,
+            self.kernel.metadata.shared,
+            self.device,
         )
         if flag_print_debug_verbose:
             print(
@@ -320,7 +325,6 @@ class PreparedKernel32:
 
 
 class JitCache(KernelInterface):
-
     def __init__(
         self,
         fn,
@@ -466,9 +470,9 @@ class JitCache(KernelInterface):
                     kwargs[config_arg] = self._last_decorator_fn._last_complete_args[
                         config_arg
                     ]
-                    autotuner_configs_dict[config_arg] = (
-                        self._last_decorator_fn._last_complete_args[config_arg]
-                    )
+                    autotuner_configs_dict[
+                        config_arg
+                    ] = self._last_decorator_fn._last_complete_args[config_arg]
             else:
                 raise RuntimeError(
                     f"[{__print_name__}] ERROR: cannot determine autotune results."
@@ -571,9 +575,9 @@ class JitCache(KernelInterface):
                     kwargs[config_arg] = self._last_decorator_fn._last_complete_args[
                         config_arg
                     ]
-                    autotuner_configs_dict[config_arg] = (
-                        self._last_decorator_fn._last_complete_args[config_arg]
-                    )
+                    autotuner_configs_dict[
+                        config_arg
+                    ] = self._last_decorator_fn._last_complete_args[config_arg]
             else:
                 raise RuntimeError(
                     f"[{__print_name__}] ERROR: cannot determine autotune results."

--- a/triton_dejavu/jit_cache.py
+++ b/triton_dejavu/jit_cache.py
@@ -366,6 +366,10 @@ class JitCache(KernelInterface):
         fn_name = fnsl[1][:-1]
         self._jit_fn = last_fn
         self._last_decorator_fn = last_decorator
+        # if autotuner is triton_dejavu, we can determine the last missing arguments
+        #  so we set the flag that the last args are stored
+        if hasattr(self._last_decorator_fn, "_need_last_args"):
+            self._last_decorator_fn._need_last_args = True
         if flag_print_debug:
             print(
                 f"[{__print_name__}] JITCache for Triton kernel {fn_name} is activated."

--- a/triton_dejavu/testing.py
+++ b/triton_dejavu/testing.py
@@ -584,6 +584,7 @@ def do_bench(
         )
         # import torch.multiprocessing as mp
         import multiprocessing as mp
+
         mp.set_start_method("spawn", force=True)
         manager = mp.Manager()
         return_dict = manager.dict({"ret": float("nan"), "stdout": "", "stderr": ""})

--- a/triton_dejavu/testing.py
+++ b/triton_dejavu/testing.py
@@ -24,8 +24,6 @@ import time
 import numpy as np
 import torch
 
-# import torch.multiprocessing as mp
-import multiprocessing as mp
 import io
 from collections import namedtuple
 import triton
@@ -411,9 +409,16 @@ def _do_bench_cudagraph(
         tb = traceback.format_exc()
         return_dict["e"] = f"Exception {e}; traceback: {tb}"
         print(tb)
+    del cache
     fn.cleanup()
     torch.cuda.empty_cache()
     torch.cuda.ipc_collect()
+    if flag_print_debug_verbose:
+        free_m, total_m = torch.cuda.mem_get_info()
+        GB_u = 1024 * 1024 * 1024
+        print(
+            f"current memory: {free_m/GB_u:.4f} GB free of total {total_m/GB_u:.4f} GB. "
+        )
     if redirect_io:
         return_dict["stdout"] = sys.stdout.getvalue()
         return_dict["stderr"] = sys.stdout.getvalue()
@@ -577,6 +582,8 @@ def do_bench(
         print(
             f"current memory: {free_m/GB_u:.4f} GB free of total {total_m/GB_u:.4f} GB. "
         )
+        # import torch.multiprocessing as mp
+        import multiprocessing as mp
         mp.set_start_method("spawn", force=True)
         manager = mp.Manager()
         return_dict = manager.dict({"ret": float("nan"), "stdout": "", "stderr": ""})


### PR DESCRIPTION
If jitcache is _not_ used, we don't need to hold the last arguments the autotuner has seen. Also, create a cuda benchmarking stream only if necessary. 